### PR TITLE
Fix esm setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,18 @@
   "version": "1.0.0",
   "description": "React hook form wrapper for Mantine components",
   "source": "src/index.ts",
-  "main": "dist/main.js",
-  "module": "dist/module.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.mjs",
   "homepage": "https://aranlucas.github.io/react-hook-form-mantine",
-  "types": "dist/types.d.ts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.mjs",
+      "require": "./dist/index.cjs.js"
+    }
+  },
   "scripts": {
     "build-storybook": "storybook build",
     "build": "parcel build",


### PR DESCRIPTION
**Issue**
Server side rendering in nextjs project was not properly picking up the esm module.js and incorrectly using the cjs which resulted in a provider / context mismatch when using FormProvider from `react-hook-form`.

**Fix**
Match the output of react-hook-form to fix resolution issue and keep in sync with that project

**Error Repro**
https://github.com/jdt3969/test-form
```
yarn
yarn dev
```

**Fix Repro**
https://github.com/jdt3969/test-form/tree/fix
```
yarn
yarn dev
```