### PR TITLE
fix: NumberInput converts input into a number

### DIFF
--- a/src/NumberInput/NumberInput.tsx
+++ b/src/NumberInput/NumberInput.tsx
@@ -35,8 +35,9 @@ export function NumberInput<T extends FieldValues>({
     <$NumberInput
       value={value}
       onChange={(e) => {
-        fieldOnChange(e);
-        onChange?.(e);
+        const newValue = e || e === 0 ? Number(e) : NaN;
+        fieldOnChange(newValue);
+        onChange?.(newValue);
       }}
       error={fieldState.error?.message}
       {...field}


### PR DESCRIPTION
Issue:
Using Zod to validate a form showed that after deleting the input and entering any value into it, the input becomes string and stays a string.

Solution:
Converting the input into a number when possible.