### PR TITLE
chore: update pnpm to 12.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
         with:
-          version: 12.2.1
           install: false
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
         with:
-          version: 12.2.1
           install: false
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
         with:
-          version: 12.2.1
           install: false
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.43"
   },
-  "packageManager": "pnpm@12.2.1",
+  "packageManager": "pnpm@12.3.1",
   "pnpm": {
     "shamefullyHoist": true,
     "strictPeerDependencies": false


### PR DESCRIPTION
Update `packageManager` from `pnpm@12.2.1` to `pnpm@12.3.1` (latest).

Verified via `npm view pnpm versions --json` – 12.3.1 is the newest release.